### PR TITLE
Refactor: restore python build; copy baseimage/alpine to legacy/alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,41 @@ Tags are currently written according to the format:
 {purpose}-{language|domain}-{version}
 ```
 
-The purpose should correspond to a folder in this repo which describes
-what we are using those images for. And the language/domain should
-correspond to the extension on a Dockerfile in that directory. E.g. the
-tag `base-node-12.0.0` corresponds to version 12.0.0 of the file in
-`base/Dockerfile.node`.
+Purpose corresponds to a folder in the repo. Language|domain corresponds
+to the suffix of a Dockerfile in that folder. For example,
+`base-node-12.0.0` is version 12.0.0 of `base/Dockerfile.node`. Note
+that's _not_ version 12.0.0 of node; it's revision 12.0.0 of the
+Dockerfile.
 
-Note that all of our images follow a semver versioning process so make
-sure to update the version accordingly based on if there are potential breaking
-changes in your update.
+Our images follow semantic versioning. Please version accordingly based on
+breaking changes in your update.
+
+## Tag Granularity
+
+There may be many ways to specify the same image. If `1.2.3` is the latest
+version of `base-node`, then:
+
+- `base-node-latest`
+- `base-node-1`
+- `base-node-1.2`
+- `base-node-1.2.3`
+
+all refer to the same image. Specifying a less-exact tag version can
+result in the image you use changing on repeat runs of `docker build`.
 
 ## How to reference one of these images
 
-To reference one of these images as the base image in one of your
-Dockerfile simply add:
+To write a Dockerfile based on one of these images, write:
 
 `FROM better/dockerimages:{purpose}-{language|domain}-{version}`
 
-For example:
+In a new Dockerfile. For example:
 
-`FROM better/dockerimages:base-node-12`
+`FROM better/dockerimages:base-node-12.0.0`
 
 ## Building one of these images
 
-To build any of these images simply run:
+To build any of these images:
 
 `make build IMAGE={purpose}-{language|domain}`
 

--- a/build/Dockerfile.python
+++ b/build/Dockerfile.python
@@ -1,0 +1,36 @@
+FROM alpine:3.10
+
+LABEL \
+maintainer="core-tech@better.com"
+
+ENV USER_ID=1000 USER=app GOPATH=/go LC_ALL=en_US.utf-8
+ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}" DIR="/home/${USER}"
+
+# System setup
+RUN addgroup -g ${USER_ID} ${USER} && adduser -D -G ${USER} -u ${USER_ID} ${USER}
+
+# System dependencies
+RUN apk add  --no-cache                                                                    \
+      linux-headers coreutils ca-certificates openssl openssl-dev                          \
+      musl-dev g++ python3 python3-dev git curl bash build-base docker                     \
+  && wget https://github.com/mozilla/sops/releases/download/3.3.1/sops-3.3.1.linux -O sops \
+  && sha1sum sops | grep af2fc3d3a29565b0d6a73249136965ffee62892f                          \
+  && chmod +x sops                                                                         \
+  && mv sops /usr/local/bin
+
+# Librdkafka for event service dependents
+RUN curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.zip > librdkafka.zip                       \
+  && echo "8b5e95318b190f40cbcd4a86d6a59dbe57b54a920d8fdf64d9c850bdf05002ca librdkafka.zip" | sha256sum -c - \
+  && unzip librdkafka.zip                                                                                    \
+  && rm librdkafka.zip                                                                                       \
+  && cd librdkafka-1.2.1                                                                                     \
+  && ./configure --prefix /usr                                                                               \
+  && make                                                                                                    \
+  && make install
+
+# Application dependencies
+RUN python3 -m ensurepip \
+  && pip3 install --upgrade pip setuptools
+
+# Check for CVE-2019-5021
+RUN grep -F 'root:!::0:::::' /etc/shadow

--- a/legacy/Dockerfile.alpine
+++ b/legacy/Dockerfile.alpine
@@ -10,27 +10,40 @@ ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}" DIR="/home/${USER}"
 RUN addgroup -g ${USER_ID} ${USER} && adduser -D -G ${USER} -u ${USER_ID} ${USER}
 
 # System dependencies
-RUN apk add  --no-cache                                                                    \
-      linux-headers coreutils ca-certificates openssl openssl-dev                          \
-      musl-dev g++ python3 python3-dev git curl bash build-base docker                     \
-  && wget https://github.com/mozilla/sops/releases/download/3.3.1/sops-3.3.1.linux -O sops \
-  && sha1sum sops | grep af2fc3d3a29565b0d6a73249136965ffee62892f                          \
-  && chmod +x sops                                                                         \
-  && mv sops /usr/local/bin
+RUN apk add --no-cache \
+  linux-headers coreutils ca-certificates openssl openssl-dev musl-dev g++ python3 python3-dev git curl bash build-base && \
+  wget https://github.com/mozilla/sops/releases/download/3.3.1/sops-3.3.1.linux -O sops && \
+  sha1sum sops | grep af2fc3d3a29565b0d6a73249136965ffee62892f && \
+  chmod +x sops && mv sops /usr/local/bin
+
+# Database SSL certificates
+COPY rds-combined-ca-bundle.pem redshift-ca-bundle.crt /tmp/
+RUN mkdir -p /etc/ssl && cp /tmp/rds-combined-ca-bundle.pem /tmp/redshift-ca-bundle.crt /etc/ssl
+
+# todo: write a script for this?
+RUN cd /tmp && \
+  csplit --elide-empty-files --quiet --prefix rds-crt rds-combined-ca-bundle.pem '/-BEGIN CERTIFICATE-/' '{*}' && \
+  for c in /tmp/rds-crt*; \
+  do mv /$c /usr/local/share/ca-certificates/aws-rds-ca-$(basename $c).crt; done
+RUN cd /tmp && \
+  csplit --elide-empty-files --quiet --prefix rs-crt redshift-ca-bundle.crt '/-BEGIN CERTIFICATE-/' '{*}' && \
+  for c in /tmp/rs-crt*; \
+  do mv /$c /usr/local/share/ca-certificates/redshift-ca-$(basename $c).crt; done
+
+RUN update-ca-certificates
 
 # Librdkafka for event service dependents
-RUN curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.zip > librdkafka.zip                       \
-  && echo "8b5e95318b190f40cbcd4a86d6a59dbe57b54a920d8fdf64d9c850bdf05002ca librdkafka.zip" | sha256sum -c - \
-  && unzip librdkafka.zip                                                                                    \
-  && rm librdkafka.zip                                                                                       \
-  && cd librdkafka-1.2.1                                                                                     \
-  && ./configure --prefix /usr                                                                               \
-  && make                                                                                                    \
-  && make install
+RUN curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.zip > librdkafka.zip && \
+  echo "8b5e95318b190f40cbcd4a86d6a59dbe57b54a920d8fdf64d9c850bdf05002ca  librdkafka.zip" | sha256sum -c - && \
+  unzip librdkafka.zip && \
+  rm librdkafka.zip && \
+  cd librdkafka-1.2.1 && \
+  ./configure --prefix /usr && \
+  make && \
+  make install
 
 # Application dependencies
-RUN python3 -m ensurepip \
-  && pip3 install --upgrade pip setuptools
+RUN python3 -m ensurepip && pip3 install --upgrade pip setuptools
 
 # Check for CVE-2019-5021
 RUN grep -F 'root:!::0:::::' /etc/shadow


### PR DESCRIPTION
build/Dockerfile.python is not the build image we deserve, but it's the
one we need right now. It was not actually a direct copy of the legacy
baseimage. So, I've copied the actual legacy baseimage to
legacy/Dockerfile.alpine, so as to preserve it as intended.