### PR TITLE
Infra+Refactor: remove unneeded check for CVE-2019-5021

### DIFF
--- a/base/Dockerfile.node
+++ b/base/Dockerfile.node
@@ -38,6 +38,3 @@ RUN  mkdir -p /etc/ssl                                                          
   && for c in /tmp/rds-crt*; do mv /$c /usr/local/share/ca-certificates/aws-rds-ca-$(basename $c).crt ; done      \
   && for c in /tmp/rs-crt* ; do mv /$c /usr/local/share/ca-certificates/redshift-ca-$(basename $c).crt; done      \
   && update-ca-certificates
-
-# Check for CVE-2019-5021
-RUN grep -F 'root:!::0:::::' /etc/shadow

--- a/build/Dockerfile.node
+++ b/build/Dockerfile.node
@@ -73,6 +73,3 @@ RUN echo "export NODE_RDKAFKA_VERSION_EXACT="$(            \
     # Get <version> from <pkg>@<version>                   \
     | cut -d@ -f2                                          \
   ) > /etc/rdkafka-info.sourceme.sh
-
-# Check for CVE-2019-5021
-RUN grep -F 'root:!::0:::::' /etc/shadow


### PR DESCRIPTION
According to the [alpine-linux security feed][0], this vulnerability has
been addressed by every release of alpine-linux since March 7 2019.
Moreover, the version of alpine-linux we're currently based on (3.10),
has _never_ been susceptible.

... Not to mention that this check was not sufficient to prevent the
vulnerability from being re-introduced by any derived image which might
have run `apk add shadow` or one of the other affected packages. So
it was really only of limited value in the first place. But anyway.

[0]: https://alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html