### PR TITLE
Refactor: improve the try-use-prebuilt-node-rdkafka.sh script

### DIFF
--- a/build/Dockerfile.node
+++ b/build/Dockerfile.node
@@ -23,15 +23,6 @@ RUN  curl -o sops -L https://github.com/mozilla/sops/releases/download/3.3.1/sop
   && chmod +x sops                                                                            \
   && mv sops /usr/local/bin
 
-# node-rdkafka for event service dependents TODO: split out / parameterize
-#
-# NOTE: The node-rdkafka version specified by ${NODE_RDKAFKA_VERSION_SPEC}
-# MUST ALSO SATISFY the version spec used by applications. Application
-# containers should in fact test this, to make sure that the spec matches
-# the version required my their version of @better/events according to
-# `npx semver`. This check is done by try-use-prebuilt-node-rdkafka.sh.
-#
-COPY scripts/try-use-prebuilt-node-rdkafka.sh /usr/local/bin/
 #
 # NOTE: npm's --unsafe-perm suppresses the "change user to nobody"
 # behavior of running with --global, so that EACCESS errors don't occur
@@ -67,3 +58,13 @@ RUN echo "export NODE_RDKAFKA_VERSION_EXACT="$(            \
     # Get <version> from <pkg>@<version>                   \
     | cut -d@ -f2                                          \
   ) > /etc/rdkafka-info.sourceme.sh
+
+# node-rdkafka for event service dependents TODO: split out / parameterize
+#
+# NOTE: The node-rdkafka version specified by ${NODE_RDKAFKA_VERSION_SPEC}
+# MUST ALSO SATISFY the version spec used by applications. Application
+# containers should in fact test this, to make sure that the spec matches
+# the version required my their version of @better/events according to
+# `npx semver`. This check is done by try-use-prebuilt-node-rdkafka.sh.
+#
+COPY scripts/try-use-prebuilt-node-rdkafka.sh /usr/local/bin/

--- a/build/scripts/try-use-prebuilt-node-rdkafka.sh
+++ b/build/scripts/try-use-prebuilt-node-rdkafka.sh
@@ -1,32 +1,65 @@
 #!/bin/sh
+function npm_list_version () {
+  local package=$1
+  # stderr is just noise; it complains when node_modules doesn't exist
+  listed=$(
+    2>/dev/null npm list \
+      --long             \
+      --parseable        \
+      "${package}"       \
+    | cut -d: -f2        \
+    | tr -d '"'
+  )
+  # ${listed} with ${package} prefix-removed
+  suffix=${listed##${package}}
+  #
+  # condition 1:
+  #   ${suffix} != ${listed}; ie: ${package} prefixes ${listed}
+  # condition 2:
+  #   ${suffix##@} != ${suffix}; ie: ${suffix} starts with '@'
+  # together:
+  #   ${listed} begins with ${package} and, once ${package} has been
+  #   removed from the start of ${listed}, the remaining characters begin
+  #   with a '@'; meaning, according to the npm version grammar, ${listed}
+  #   and ${package} refer to the same @<scope>/<name> module-spec.
+  #
+  if :                                 \
+    && [[ ${suffix}    != ${listed} ]] \
+    && [[ ${suffix##@} != ${suffix} ]] \
+  ; then
+    echo ${listed}
+  fi
+}
 if [[ -e "/etc/rdkafka-info.sourceme.sh" ]]; then
   source "/etc/rdkafka-info.sourceme.sh"
-  if [[ -z $NODE_RDKAFKA_INSTALL ]]; then
-    >2 printf '%s%s'                        \
+  if [[ -z ${NODE_RDKAFKA_INSTALL} ]]; then
+    1>&2 printf '%s%s'                      \
       '$NODE_RDKAFKA_INSTALL is empty;'     \
       ' cannot find prebuilt node-rdkafka!'
     exit 1
   fi
-  if [[ -z $NODE_RDKAFKA_VERSION_EXACT ]]; then
-    >2 printf '%s%s'                                            \
+  if [[ -z ${NODE_RDKAFKA_VERSION_EXACT} ]]; then
+    1>2 printf '%s%s'                                           \
       '$NODE_RDKAFKA_VERSION_EXACT is empty;'                   \
       ' cannot check compatability with prebuilt node-rdkafka!'
     exit 1
   fi
-  events_exact=$(
-    # stderr is just noise; it complains when node_modules doesn't exist
-    2>/dev/null npm list \
-        --long           \
-        --parseable      \
-        @better/events   \
-      | cut -d: -f2      \
-      | tr -d '"'
-  )
-  rdkafka_spec=$(
-    npm info                    \
-      "${events_exact}"         \
-      dependencies.node-rdkafka
-  )
+  events_exact=$(npm_list_version "@better/events")
+  if [[ -z ${events_exact} ]]; then
+    1>&2 printf 'No exact needed @better/events version found!\n'
+    exit 1
+  fi
+  rdkafka_spec=$(npm info "${events_exact}" dependencies.node-rdkafka)
+  if [[ -z ${rdkafka_spec} ]]; then
+    rdkafka_spec=$(
+      npm_list_version "node-rdkafka" \
+        | cut -d@ -f2
+    )
+  fi
+  if [[ -z ${rdkafka_spec} ]]; then
+    1>&2 printf 'No ${rdkafka_spec} for this package could be determined!\n'
+    exit 1
+  fi
   if $(
     # We don't care about any of this output, only success on exit
     &>/dev/null npx semver          \
@@ -35,7 +68,14 @@ if [[ -e "/etc/rdkafka-info.sourceme.sh" ]]; then
   ); then
     if [[ ! -d "./node_modules" ]]; then mkdir "./node_modules"; fi
     rm --recursive --force ./node_modules/node-rdkafka
-    echo "Copying $NODE_RDKAFKA_INSTALL to ./node_modules/node-rdkafka..."
-    cp --recursive $NODE_RDKAFKA_INSTALL ./node_modules/node-rdkafka
+    echo "Copying ${NODE_RDKAFKA_INSTALL} to ./node_modules/node-rdkafka..."
+    cp --recursive ${NODE_RDKAFKA_INSTALL} ./node_modules/node-rdkafka
+  else
+    1>&2 printf 'node-rdkafka@%s not satisfied by prebuilt @ %s\n' \
+      ${rdkafka_spec} ${NODE_RDKAFKA_VERSION_EXACT}
+    exit 1
   fi
+else
+  1>&2 printf 'no rdkafka info found at /etc/rdkafka-info.sourceme.sh\n'
+  exit 1
 fi


### PR DESCRIPTION
It now works correctly even if it is invoked in the directory of the `@better/events` package, and it prints more and more informative error messages for failure cases.

Additionally, move the COPY for the script to the end of the node build Dockerfile, so that changing the script doesn't cache-bust a bunch of unrelated layers.