### PR TITLE
Build+Bugfix: only force-push non-version tags

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -54,9 +54,12 @@ echo ""
 echo "Updating tags..."
 
 for tag in "${tags[@]}"; do
+  if [[ ${tag} == "latest" ]]; then
+    force='-f'
+  fi
   echo "Tagging ${tag}"
-  git tag -f $tag
+  git tag ${force} $tag
 
   echo "Pushing ${tag}"
-  git push -f origin ${tag}
+  git push ${force} origin ${tag}
 done


### PR DESCRIPTION
Otherwise it is possible to overwrite a previously-built version...
Which should not be easy to accidentally do!