### PR TITLE
Add 4lw config to zookeeper to aid in kafka readiness checking

### DIFF
--- a/config/kafka/local-zookeeper.cfg
+++ b/config/kafka/local-zookeeper.cfg
@@ -18,3 +18,6 @@ dataDir=/tmp/zookeeper
 clientPort=2181
 # disable the per-ip limit on the number of connections since this is a non-production config
 maxClientCnxns=0
+# Allow some 4 letter word commands because this is non-production and they are helpful
+# for determining whether or not Kafka is fully up
+4lw.commands.whitelist=stat,ruok,conf,isro,dump


### PR DESCRIPTION
Going to self-merge because this is a trivial change and want to see if it works all the way through. Tested locally and it was working.