### PR TITLE
Pin python alpine, add postgres to python build, add cyrus-sasl-plain for activemq auth

### DIFF
--- a/base/Dockerfile.python
+++ b/base/Dockerfile.python
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3-alpine3.11
 
 LABEL maintainer="core-tech@better.com"
 

--- a/build/Dockerfile.python
+++ b/build/Dockerfile.python
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3-alpine3.11
 
 LABEL maintainer="core-tech@better.com"
 
@@ -27,6 +27,7 @@ RUN :                                                         \
     python3-dev                                               \
     py3-setuptools                                            \
     librdkafka-dev                                            \
+    postgresql-dev                                            \
   # Run common install scripts                                \
   && chmod +x /tmp/scripts/common/install-rds-certificates.sh \
   && chmod +x /tmp/scripts/common/install-sops.sh             \

--- a/hooks/build
+++ b/hooks/build
@@ -5,6 +5,8 @@ export BASE_APK_DEPENDENCIES=(
   openssl
   coreutils
   ca-certificates
+  # qpid proton (for activemq) needs this library to authenticate
+  cyrus-sasl-plain
   # librdkafka needs these .so's at runtime
   lz4-dev
   cyrus-sasl-dev


### PR DESCRIPTION
- Added postgresql-dev to the python build image because it is very often a build time dependency and so we might as well include it. Leave it out of the base image to keep them small. 
- Also added `cyrus-sasl-plain` as a base APK dependency, since we need cyrus-sasl for librdkafka but if you don't include that library then activemq cannot authenticate properly
- Pin python base and build alpine version to 3.11