### PR TITLE
Define image build-python.tox with magic tox powers

### DIFF
--- a/build/Dockerfile.python.tox
+++ b/build/Dockerfile.python.tox
@@ -1,0 +1,38 @@
+# -*- mode: sh; -*-
+FROM better/dockerimages:build-python-latest
+LABEL maintainer="core-tech@better.com"
+
+# First, we install pyenv, which we will use to install and manage several different versions of Python
+RUN git clone https://github.com/pyenv/pyenv.git /etc/pyenv
+RUN echo 'export PYENV_ROOT="/etc/pyenv"' >> /etc/profile
+RUN echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> /etc/profile
+RUN echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> /etc/profile
+
+# Then, we install dependencies for Python
+RUN apk add bzip2-dev
+RUN apk add readline-dev
+RUN apk add sqlite-dev
+
+# Now, we install a couple of useful scripts
+COPY build/scripts/forall-py.sh /usr/bin/forall-py
+COPY build/scripts/with-pyenv.sh /usr/bin/with-pyenv
+
+# Next, we use pyenv to install the versions of Python we plan to support
+RUN with-pyenv install 3.6.8
+RUN with-pyenv install 3.7.5
+RUN with-pyenv install 3.8.2
+ENV PYENV_VERSIONS "3.6.8 3.7.5 3.8.2"
+RUN with-pyenv shell $PYENV_VERSIONS
+
+# Next, we use forall-py to install pytest, coverage, and tox for all of our Pythons.
+RUN forall-py pip install --upgrade pip
+RUN forall-py pip install --upgrade pytest coverage tox mypy
+
+# Then, we set up environment so that users can run the commands we support easily.
+ENV PYENV_SHELL ash
+ENV PATH /etc/pyenv/shims:/etc/pyenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PYENV_ROOT /etc/pyenv
+ENV PYENV_VERSION 3.6.8:3.7.5:3.8.2
+
+# We don't set an entrypoint because the user is expected to derive or compose
+# another container using this as a base image.

--- a/build/scripts/forall-py.sh
+++ b/build/scripts/forall-py.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+source /etc/profile
+
+pyenv shell $PYENV_VERSIONS
+pyenv_versions=$(pyenv versions | grep '\*' | awk '{print $2}')
+
+for version in $pyenv_versions; do
+    echo Running $* in Python $version...
+    pyenv shell $version
+    pyenv exec $*
+    echo Running $* in Python $version...done
+    echo
+    done

--- a/build/scripts/with-pyenv.sh
+++ b/build/scripts/with-pyenv.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source /etc/profile
+
+pyenv $*


### PR DESCRIPTION
In this commit, we define a new python build image, which includes `pytest`,
`coverage`, `mypy`, and `tox`. This allows users to run their tests in all
supported (implicitly, anyway) versions of Python, generating coverage reports
along the way.