### PR TITLE
Add sqlite2 tool to build image

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ Available TYPES are
 - `minor`
 - `patch`
 
+### Adding a package to APK for all images to use
+
+If you need to add an APK package to all images, you can do so by modifying
+either `BASE_APK_DEPENDENCIES` or `BUILD_APK_DEPENDENCIES` in `hooks/build`.
+Then, when you execute `make build-IMAGE` as above, it will pick up the packages
+you added.
+
 ## Adding a fully new image
 
 To add a new image it should be as simple as creating a new Dockerfile

--- a/build/Dockerfile.python
+++ b/build/Dockerfile.python
@@ -28,6 +28,10 @@ RUN :                                                         \
     py3-setuptools                                            \
     librdkafka-dev                                            \
     postgresql-dev                                            \
+    bzip2-dev                                                 \
+    readline-dev                                              \  
+    sqlite-dev                                                \
+    sqlite                                                    \
   # Run common install scripts                                \
   && chmod +x /tmp/scripts/common/install-rds-certificates.sh \
   && chmod +x /tmp/scripts/common/install-sops.sh             \

--- a/build/Dockerfile.python
+++ b/build/Dockerfile.python
@@ -28,10 +28,6 @@ RUN :                                                         \
     py3-setuptools                                            \
     librdkafka-dev                                            \
     postgresql-dev                                            \
-    bzip2-dev                                                 \
-    readline-dev                                              \  
-    sqlite-dev                                                \
-    sqlite                                                    \
   # Run common install scripts                                \
   && chmod +x /tmp/scripts/common/install-rds-certificates.sh \
   && chmod +x /tmp/scripts/common/install-sops.sh             \

--- a/hooks/build
+++ b/hooks/build
@@ -22,12 +22,16 @@ export BUILD_APK_DEPENDENCIES=(
   openssh
   yaml-dev
   zlib-dev
+  bzip2-dev
   build-base
   libffi-dev
   libxslt-dev
   openssl-dev
   linux-headers
   libjpeg-turbo-dev
+  readline-dev
+  sqlite-dev
+  sqlite
 )
 
 # Will this work on Docker Hub? Is `git` available? Should be...


### PR DESCRIPTION
In this commit, we add the `sqlite3` command-line utility to the basic python
build image. This allows targets such as `ci-publish` to be able to use sqlite
when building pypi packages.