### PR TITLE
Pin alpine, rdkafka, and confluent-kafka to latest versions

### DIFF
--- a/base/Dockerfile.python
+++ b/base/Dockerfile.python
@@ -1,4 +1,4 @@
-FROM python:3-alpine3.11
+FROM python:3-alpine3.12
 
 LABEL maintainer="core-tech@better.com"
 
@@ -16,7 +16,9 @@ RUN :                                                         \
     # Base dependencies                                       \
     ${BASE_APK_DEPENDENCIES}                                  \
     # Librdkafka                                              \
-    librdkafka                                                \
+    build-base                                                \
+    librdkafka=1.4.2-r0                                       \
+    librdkafka-dev=1.4.2-r0                                   \
   # Run common install scripts                                \
   && chmod +x /tmp/scripts/common/install-rds-certificates.sh \
   && chmod +x /tmp/scripts/common/install-sops.sh             \
@@ -28,4 +30,6 @@ RUN :                                                         \
   && ln -s /usr/local/bin/python /usr/bin/python              \
   && ln -s /usr/local/bin/pip /usr/bin/pip3                   \
   && ln -s /usr/local/bin/pip /usr/bin/pip                    \
+  # Install confluent-kafka so we know it works.              \
+  && pip install confluent-kafka==1.4.2                       \
   ;


### PR DESCRIPTION
In this PR I fix the cimpl problem once and for all. I do this by updating Alpine to the latest version, which allows me to pin `rdkafka` to 1.4.2-r0 (the latest version available). Then, I install `build-base`, which is required in order to `pip install confluent-kafka==1.4.2`, which is also the latest kafka available.

Unfortunately, this makes the image a bit larger. If we want to avoid doing this (perhaps in the future), we'll probably have to maintain our own build of `confluent-kafka` on Artifactory. For now, however, I expect this will solve the problem.

N.b.: Clients _must_ pin `confluent-kafka` to **1.4.2** and _not_ 1.3.0 in order to use this version.