### PR TITLE
ct-516-update-kafka-libraries-in-python_postgres-image

### DIFF
--- a/build/Dockerfile.python-postgres
+++ b/build/Dockerfile.python-postgres
@@ -26,7 +26,8 @@ RUN :                                                         \
   && apk add --no-cache                                       \
     python3-dev                                               \
     py3-setuptools                                            \
-    librdkafka-dev                                            \
+    librdkafka=1.4.2-r0                                       \
+    librdkafka-dev=1.4.2-r0                                   \
   # Run common install scripts                                \
   && chmod +x /tmp/scripts/common/install-rds-certificates.sh \
   && chmod +x /tmp/scripts/common/install-sops.sh             \
@@ -35,4 +36,6 @@ RUN :                                                         \
   # Run build install scripts                                 \
   && chmod +x /tmp/scripts/build/install-semver-tool.sh       \
   && /tmp/scripts/build/install-semver-tool.sh                \
+  # Install a pinned version of confluent-kafka               \
+  && pip install confluent-kafka==1.4.2                       \
   ;


### PR DESCRIPTION
- Update build-python-postgres to use pinned Kafka versions
