### PR TITLE
plat-32__dockerimages__Update-all-confluent-kafka-to-1.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,4 +77,13 @@ help:
 	@ echo 'To release an image: make release-{major,minor,patch}-imagename'
 	@ echo 'To build all python images: make build-all-python-images'
 	@ echo 'For more information, c.f. README.'
-	@ echo $(.PHONY)
+	@ echo
+	@ echo 'Make targets'
+	@ echo '============'
+	@ echo
+	@ perl -ne 'print if /^[^\s]*:/' Makefile | grep -v .PHONY | cut -d':' -f1 | sort -u
+	@ echo
+	@ echo 'Phony make targets'
+	@ echo '=================='
+	@ echo
+	@ make -np | grep \^.PHONY: | sed 's/^\.PHONY: *//' | tr " " "\n" | sort -u

--- a/base/Dockerfile.python
+++ b/base/Dockerfile.python
@@ -8,6 +8,7 @@ ARG BASE_APK_DEPENDENCIES
 COPY                                         \
   scripts/common/install-rds-certificates.sh \
   scripts/common/install-sops.sh             \
+  scripts/common/install-latest-librdkafka.sh \
   /tmp/scripts/common/
 RUN :                                                         \
   && apk update                                               \
@@ -17,19 +18,17 @@ RUN :                                                         \
     ${BASE_APK_DEPENDENCIES}                                  \
     # Librdkafka                                              \
     build-base                                                \
-    librdkafka=1.4.2-r0                                       \
-    librdkafka-dev=1.4.2-r0                                   \
   # Run common install scripts                                \
   && chmod +x /tmp/scripts/common/install-rds-certificates.sh \
   && chmod +x /tmp/scripts/common/install-sops.sh             \
+  && chmod +x /tmp/scripts/common/install-latest-librdkafka.sh \
   && /tmp/scripts/common/install-rds-certificates.sh          \
   && /tmp/scripts/common/install-sops.sh                      \
+  && /tmp/scripts/common/install-latest-librdkafka.sh         \
   # link python to match what alpine apk does                 \
   && ln -s /usr/local/bin/python /usr/bin/python3.8           \
   && ln -s /usr/local/bin/python /usr/bin/python3             \
   && ln -s /usr/local/bin/python /usr/bin/python              \
   && ln -s /usr/local/bin/pip /usr/bin/pip3                   \
   && ln -s /usr/local/bin/pip /usr/bin/pip                    \
-  # Install confluent-kafka so we know it works.              \
-  && pip install confluent-kafka==1.4.2                       \
   ;

--- a/build/Dockerfile.python
+++ b/build/Dockerfile.python
@@ -9,6 +9,7 @@ ARG BUILD_APK_DEPENDENCIES
 COPY                                         \
   scripts/common/install-rds-certificates.sh \
   scripts/common/install-sops.sh             \
+  scripts/common/install-latest-librdkafka.sh \
   /tmp/scripts/common/
 # Copy needed build installation scripts
 COPY                                   \
@@ -26,17 +27,15 @@ RUN :                                                         \
   && apk add --no-cache                                       \
     python3-dev                                               \
     py3-setuptools                                            \
-    librdkafka=1.4.2-r0                                       \
-    librdkafka-dev=1.4.2-r0                                   \
     postgresql-dev                                            \
   # Run common install scripts                                \
   && chmod +x /tmp/scripts/common/install-rds-certificates.sh \
   && chmod +x /tmp/scripts/common/install-sops.sh             \
+  && chmod +x /tmp/scripts/common/install-latest-librdkafka.sh \
   && /tmp/scripts/common/install-rds-certificates.sh          \
   && /tmp/scripts/common/install-sops.sh                      \
+  && /tmp/scripts/common/install-latest-librdkafka.sh         \
   # Run build install scripts                                 \
   && chmod +x /tmp/scripts/build/install-semver-tool.sh       \
   && /tmp/scripts/build/install-semver-tool.sh                \
-  # Install a pinned version of confluent-kafka               \
-  && pip install confluent-kafka==1.4.2                       \
   ;

--- a/build/Dockerfile.python-postgres
+++ b/build/Dockerfile.python-postgres
@@ -9,6 +9,7 @@ ARG BUILD_APK_DEPENDENCIES
 COPY                                         \
   scripts/common/install-rds-certificates.sh \
   scripts/common/install-sops.sh             \
+  scripts/common/install-latest-librdkafka.sh \
   /tmp/scripts/common/
 # Copy needed build installation scripts
 COPY                                   \
@@ -26,16 +27,14 @@ RUN :                                                         \
   && apk add --no-cache                                       \
     python3-dev                                               \
     py3-setuptools                                            \
-    librdkafka=1.4.2-r0                                       \
-    librdkafka-dev=1.4.2-r0                                   \
   # Run common install scripts                                \
   && chmod +x /tmp/scripts/common/install-rds-certificates.sh \
   && chmod +x /tmp/scripts/common/install-sops.sh             \
+  && chmod +x /tmp/scripts/common/install-latest-librdkafka.sh \
   && /tmp/scripts/common/install-rds-certificates.sh          \
   && /tmp/scripts/common/install-sops.sh                      \
+  && /tmp/scripts/common/install-latest-librdkafka.sh         \
   # Run build install scripts                                 \
   && chmod +x /tmp/scripts/build/install-semver-tool.sh       \
   && /tmp/scripts/build/install-semver-tool.sh                \
-  # Install a pinned version of confluent-kafka               \
-  && pip install confluent-kafka==1.4.2                       \
   ;

--- a/scripts/common/install-latest-librdkafka.sh
+++ b/scripts/common/install-latest-librdkafka.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#### Install latest librdkafka, right from the GIT repo.
+
+### Define the version of kafka we are pinning to.
+kafka_version=1.5.0
+
+
+### Install librdkafka
+## Install dependencies
+apk add --no-cache libressl-dev || exit 2
+apk add --no-cache cyrus-sasl-dev || exit 2
+apk add --no-cache zstd-dev || exit 2
+apk add --no-cache zlib-dev || exit 2
+apk add --no-cache git || exit 2
+apk add --no-cache make || exit 2
+apk add --no-cache gcc || exit 2
+apk add --no-cache g++ || exit 2
+
+## Fetch librdkafka from github
+git clone https://github.com/edenhill/librdkafka.git || exit 2
+cd librdkafka/ || exit 2
+
+## Check out the version we plan to build, so it's pinned.
+git checkout v${kafka_version} || exit 2
+
+## Actually build and install librdkafka
+./configure --install-deps || exit 2
+make || exit 2
+make install || exit 2
+
+## Install the confluent kafka python library
+pip install confluent-kafka==${kafka_version} || exit 2


### PR DESCRIPTION
In this PR, I update all of the python images to use the latest kafka. Because alpine doesn't support the latest kafka, I also created an install script that takes care of installing tools, then cloning and building kafka from source. I specifically check out the tag for version 1.5, to effectively pin to that version. Going forward, updating to the latest kafka should be as simple as changing the `kafka_version` variable inside the `install-latest-librdkafka.sh`, then bumping all of the python images.

- Update all python images to use kafka 1.5
