### PR TITLE
Slimming the snake: part 1: map dependencies between alpine and debian

### DIFF
--- a/base/Dockerfile.dataengineering
+++ b/base/Dockerfile.dataengineering
@@ -9,8 +9,8 @@ LABEL variant="data-engineering"
 ARG PIP="pip3 install --no-cache-dir"
 ARG APT="apt-get -y --no-install-recommends install"
 
-ENV USER_ID=1000 
-ENV USER=app 
+ENV USER_ID=1000
+ENV USER=app
 
 RUN addgroup --gid ${USER_ID} ${USER}
 RUN adduser --home /home/${USER} \
@@ -34,25 +34,25 @@ RUN :                                                         \
   && chmod +x /tmp/scripts/common/install-sops.sh             \
   && /tmp/scripts/common/install-rds-certificates.sh          \
   && /tmp/scripts/common/install-sops.sh                      \
-  && ln -s /usr/include/locale.h /usr/include/xlocale.h     
+  && ln -s /usr/include/locale.h /usr/include/xlocale.h
 
 # data science first
 RUN :                                                         \
   && ${APT} python3.7 python3-pip libffi-dev                  \
            libfreetype6-dev pkg-config libpng-dev             \
-	   python3-dev build-essential libffi-dev 
+	   python3-dev build-essential libffi-dev
 
 
 RUN : \
   && ${PIP} six==1.13.0 setuptools==45.2.0 packaging==20.3 docutils==0.16 \
-            cryptography==2.8 
+            cryptography==2.8
 
 RUN : \
   && ${PIP} numpy==1.17.0 pandas==0.24.0 scipy==1.2.0         \
             matplotlib==2.2 seaborn==0.8 statsmodels==0.9.0    \
             pystan==2.19.1.1 prophet==0.1.1 timelines==0.2  \
-  && ${PIP} scikit-learn==0.19.2                          \ 
-  && python3 -c 'import matplotlib, numpy, pandas, seaborn, sklearn, statsmodels'                                                          
+  && ${PIP} scikit-learn==0.19.2                          \
+  && python3 -c 'import matplotlib, numpy, pandas, seaborn, sklearn, statsmodels'
 # data access and infra
 RUN : \
   && ${APT} postgresql-11 libpq-dev freetds-bin freetds-dev unixodbc-dev    \
@@ -66,7 +66,7 @@ RUN : \
             'jellyfish>=0.7.2' Cython==0.28.3 urllib3==1.25.8                        \
             botocore==1.15.14 boto3==1.12.13 paramiko==2.4.1 psutil==5.7.0 beautifulsoup4==4.8.2 \
             google-api-python-client google-auth-oauthlib==0.2.0 'googlemaps>=3.1.3' \
-  && apt-get clean 
+  && apt-get clean
 
 ENV PATH="/usr/lib/postgresql/11/bin:${PATH}"
 

--- a/base/Dockerfile.dataengineering
+++ b/base/Dockerfile.dataengineering
@@ -3,8 +3,8 @@ FROM debian:buster-slim
 LABEL variant="data-engineering"
 
 # ignored
-# ARG BASE_APK_DEPENDENCIES
-# ARG BUILD_APK_DEPENDENCIES
+# ARG BASE_DEPENDENCIES
+# ARG BUILD_DEPENDENCIES
 
 ARG PIP="pip3 install --no-cache-dir"
 ARG APT="apt-get -y --no-install-recommends install"
@@ -40,7 +40,7 @@ RUN :                                                         \
 RUN :                                                         \
   && ${APT} python3.7 python3-pip libffi-dev                  \
            libfreetype6-dev pkg-config libpng-dev             \
-	   python3-dev build-essential libffi-dev
+           python3-dev build-essential libffi-dev
 
 
 RUN : \

--- a/hooks/build
+++ b/hooks/build
@@ -1,47 +1,83 @@
 #!/bin/bash
-export BASE_APK_DEPENDENCIES=(
-  bash
-  curl
-  openssl
-  coreutils
-  ca-certificates
+BASE_DEPENDENCIES_MAP=(
+  # alpine          debian
+  bash              %
+  curl              %
+  openssl           %
+  coreutils         %
+  ca-certificates   %
   # qpid proton (for activemq) needs this library to authenticate
-  cyrus-sasl-plain
+  cyrus-sasl-plain  sasl2-bin
   # librdkafka needs these .so's at runtime
-  lz4-dev
-  cyrus-sasl-dev
+  lz4-dev           liblz4-dev
+  cyrus-sasl-dev    libsasl2-dev
 )
 
-export BUILD_APK_DEPENDENCIES=(
-  jq
-  git
-  tar
-  make
-  gnupg
-  docker
-  openssh
-  yaml-dev
-  zlib-dev
-  bzip2-dev
-  build-base
-  libffi-dev
-  libxslt-dev
-  openssl-dev
-  linux-headers
-  libjpeg-turbo-dev
-  readline-dev
-  sqlite-dev
-  sqlite
+BUILD_DEPENDENCIES_MAP=(
+  # alpine           debian
+  jq                 %
+  gcc                %
+  git                %
+  tar                %
+  make               %
+  gnupg              %
+  docker             %
+  sqlite             %
+  openssh            openssh-client
+  yaml-dev           libyaml-dev
+  zlib-dev           zlib1g-dev
+  bzip2-dev          lbzip2
+  build-base         build-essential
+  libffi-dev         %
+  sqlite-dev         libsqlite-dev
+  libxslt-dev        libxslt1-dev
+  openssl-dev        libssh-dev
+  readline-dev       libreadline-dev
+  linux-headers      linux-headers-amd64
+  libjpeg-turbo-dev  libjpeg62-turbo-dev
 )
 
-# Will this work on Docker Hub? Is `git` available? Should be...
+BASE_ALPINE_DEPENDENCIES=()
+BASE_DEBIAN_DEPENDENCIES=()
+for index in $(seq 0 2 ${#BASE_DEPENDENCIES_MAP[@]}); do
+  alpine_name=${BASE_DEPENDENCIES_MAP[${index}]}
+  debian_name=${BASE_DEPENDENCIES_MAP[$((${index} + 1))]}
+  if [[ "${debian_name}" == '%' ]]; then
+    debian_name=${alpine_name}
+  fi
+  BASE_ALPINE_DEPENDENCIES+=(${alpine_name})
+  BASE_DEBIAN_DEPENDENCIES+=(${debian_name})
+done
+
+BUILD_ALPINE_DEPENDENCIES=()
+BUILD_DEBIAN_DEPENDENCIES=()
+for index in $(seq 0 2 ${#BUILD_DEPENDENCIES_MAP[@]}); do
+  alpine_name=${BUILD_DEPENDENCIES_MAP[${index}]}
+  debian_name=${BUILD_DEPENDENCIES_MAP[$((${index} + 1))]}
+  if [[ "${debian_name}" == '%' ]]; then
+    debian_name=${alpine_name}
+  fi
+  BUILD_ALPINE_DEPENDENCIES+=(${alpine_name})
+  BUILD_DEBIAN_DEPENDENCIES+=(${debian_name})
+done
+
 git_root=$(git rev-parse --show-toplevel)
+
+if [[ "${DOCKERFILE_PATH}" == *python* ]]; then
+  BASE_DEPENDENCIES="${BASE_DEBIAN_DEPENDENCIES[*]}"
+  BUILD_DEPENDENCIES="${BUILD_DEBIAN_DEPENDENCIES[*]}"
+else
+  BASE_DEPENDENCIES="${BASE_ALPINE_DEPENDENCIES[*]}"
+  BUILD_DEPENDENCIES="${BUILD_ALPINE_DEPENDENCIES[*]}"
+fi
 
 # ${IMAGE_NAME}      is defined by Docker Hub: {repo}:{tag}
 # ${DOCKERFILE_PATH} is defined by Docker Hub: {path}
-docker build                                                        \
-  --build-arg BASE_APK_DEPENDENCIES="${BASE_APK_DEPENDENCIES[*]}"   \
-  --build-arg BUILD_APK_DEPENDENCIES="${BUILD_APK_DEPENDENCIES[*]}" \
-  --tag  "${IMAGE_NAME}"                                            \
-  --file "${git_root}/${DOCKERFILE_PATH}"                           \
+docker build                                                    \
+  --build-arg BASE_DEPENDENCIES="${BASE_DEPENDENCIES[*]}"       \
+  --build-arg BUILD_DEPENDENCIES="${BUILD_DEPENDENCIES[*]}"     \
+  --build-arg BASE_APK_DEPENDENCIES="${BASE_DEPENDENCIES[*]}"   \
+  --build-arg BUILD_APK_DEPENDENCIES="${BUILD_DEPENDENCIES[*]}" \
+  --tag  "${IMAGE_NAME}"                                        \
+  --file "${git_root}/${DOCKERFILE_PATH}"                       \
   ${git_root}


### PR DESCRIPTION
Enhances the `hooks/build` script with package names for corresponding packages in debian.

This was mostly a manual process involving some trial and error, but I can confirm that `python:3.7.3-slim` (debian buster) successfully installs the lists of packages in `{BASE,BUILD}_DEBIAN_DEPENDENCIES`. To the best of my knowledge, each package is correctly tracked to its corresponding package in Debian, though I recommend that others take a cursory look to make sure there are no obvious mistakes or typoes.

Introduces new, generalized `{BASE,BUILD}_DEPENDENCIES` build argument. Preserves the `*_APK_*` build arguments; these can be removed in a follow-up once images are updated to use the new variables.