### PR TITLE
Feat+Bugfix: common apt configuration, no more flags

### DIFF
--- a/base/Dockerfile.dataengineering
+++ b/base/Dockerfile.dataengineering
@@ -7,7 +7,6 @@ LABEL variant="data-engineering"
 # ARG BUILD_DEPENDENCIES
 
 ARG PIP="pip3 install --no-cache-dir"
-ARG APT="apt-get -y --no-install-recommends install"
 
 ENV USER_ID=1000
 ENV USER=app
@@ -22,6 +21,9 @@ RUN adduser --home /home/${USER} \
             --disabled-login   \
             ${USER}
 
+# Copy apt configuration
+COPY config/debian/etc/apt/apt.conf /etc/apt/
+
 COPY                                         \
   scripts/common/install-rds-certificates.sh \
   scripts/common/install-sops.sh             \
@@ -29,7 +31,7 @@ COPY                                         \
 RUN :                                                         \
   && apt-get update                                           \
   # Run common install scripts                                \
-  && ${APT} wget git less bash curl openssl coreutils ca-certificates jq tar \
+  && apt-get install wget git less bash curl openssl coreutils ca-certificates jq tar \
   && chmod +x /tmp/scripts/common/install-rds-certificates.sh \
   && chmod +x /tmp/scripts/common/install-sops.sh             \
   && /tmp/scripts/common/install-rds-certificates.sh          \
@@ -38,7 +40,7 @@ RUN :                                                         \
 
 # data science first
 RUN :                                                         \
-  && ${APT} libffi-dev libfreetype6-dev pkg-config libpng-dev \
+  && apt-get install libffi-dev libfreetype6-dev pkg-config libpng-dev \
            python3-dev build-essential libffi-dev
 
 
@@ -54,7 +56,7 @@ RUN : \
   && python3 -c 'import matplotlib, numpy, pandas, seaborn, sklearn, statsmodels'
 # data access and infra
 RUN : \
-  && ${APT} postgresql-11 libpq-dev freetds-bin freetds-dev unixodbc-dev    \
+  && apt-get install postgresql-11 libpq-dev freetds-bin freetds-dev unixodbc-dev    \
   && chown "${USER}" /run/postgresql                                  \
   && ${PIP} psycopg2==2.8.4 pyodbc==4.0.28 flask-sqlalchemy==2.4.1    \
             SQLAlchemy==1.2.8 pg8000==1.13.2                          \

--- a/base/Dockerfile.python
+++ b/base/Dockerfile.python
@@ -4,6 +4,9 @@ LABEL maintainer="core-tech@better.com"
 
 ARG BASE_DEPENDENCIES
 
+# Copy apt configuration
+COPY config/debian/etc/apt/apt.conf /etc/apt/
+
 # Install the base requirements
 COPY                                         \
   scripts/common/install-rds-certificates.sh \
@@ -11,9 +14,9 @@ COPY                                         \
   scripts/common/install-librdkafka.sh       \
   /tmp/scripts/common/
 RUN :                                                                \
-  && apt-get update --yes                                            \
-  && apt-get upgrade --yes                                           \
-  && apt-get install --no-install-recommends --yes                   \
+  && apt-get update                                                  \
+  && apt-get upgrade                                                 \
+  && apt-get install                                                 \
     # Base dependencies                                              \
     ${BASE_DEPENDENCIES}                                             \
     # Librdkafka                                                     \

--- a/build/Dockerfile.python
+++ b/build/Dockerfile.python
@@ -5,6 +5,9 @@ LABEL maintainer="core-tech@better.com"
 ARG BASE_DEPENDENCIES
 ARG BUILD_DEPENDENCIES
 
+# Copy apt configuration
+COPY config/debian/etc/apt/apt.conf /etc/apt/
+
 # Copy needed common installation scripts
 COPY                                         \
   scripts/common/install-rds-certificates.sh \
@@ -17,9 +20,9 @@ COPY                                   \
   /tmp/scripts/build/
 # Install packages then run installation scripts
 RUN :                                                         \
-  && apt-get update --yes                                     \
-  && apt-get upgrade --yes                                    \
-  && apt-get install --no-install-recommends --yes            \
+  && apt-get update                                           \
+  && apt-get upgrade                                          \
+  && apt-get install                                          \
     # Base dependencies                                       \
     ${BASE_DEPENDENCIES}                                      \
     # Base build dependencies                                 \

--- a/build/Dockerfile.python-postgres
+++ b/build/Dockerfile.python-postgres
@@ -5,6 +5,9 @@ LABEL maintainer="core-tech@better.com"
 ARG BASE_DEPENDENCIES
 ARG BUILD_DEPENDENCIES
 
+# Copy apt configuration
+COPY config/debian/etc/apt/apt.conf /etc/apt/
+
 # Copy needed common installation scripts
 COPY                                         \
   scripts/common/install-rds-certificates.sh \
@@ -17,16 +20,16 @@ COPY                                   \
   /tmp/scripts/build/
 # Install packages then run installation scripts
 RUN :                                                         \
-  && apt-get update --yes                                     \
-  && apt-get upgrade --yes                                    \
+  && apt-get update                                           \
+  && apt-get upgrade                                          \
   # Install common core dependencies                          \
-  && apt-get install --no-install-recommends --yes            \
+  && apt-get install                                          \
     # Base dependencies                                       \
     ${BASE_DEPENDENCIES}                                      \
     # Base build dependencies                                 \
     ${BUILD_DEPENDENCIES}                                     \
   # FIXME: install python for build - VERSION NOT CONTROLLED  \
-  && apt-get install --no-install-recommends --yes            \
+  && apt-get install                                          \
     python3                                                   \
     python3-dev                                               \
     python3-pip                                               \

--- a/config/debian/etc/apt/apt.conf
+++ b/config/debian/etc/apt/apt.conf
@@ -1,0 +1,2 @@
+apt::install-recommends "false";
+apt::get::assume-yes "true";


### PR DESCRIPTION
```
apt-config --option 'APT::PleaseSuckLess="true";' dump >> /etc/apt/apt.conf
```

Not passing `--yes` somewhere caused an `apt-get clean` or an `apt-get autoremove` to fail and block an image build, so I decided to set all our "use every time or you'll regret it" apt flags in `/etc/apt/apt.conf` instead.