### PR TITLE
plat-970__dockerimages__Fix-sqlite-dependency

### DIFF
--- a/build/Dockerfile.python.tox
+++ b/build/Dockerfile.python.tox
@@ -1,4 +1,4 @@
-FROM better/dockerimages:build-python-2
+FROM better/dockerimages:build-python-latest
 LABEL maintainer="core-tech@better.com"
 
 ENV                               \
@@ -50,3 +50,9 @@ RUN :                    \
   && pipx install tox    \
   && pipx install mypy   \
   && pipx install coverage
+
+# For some reason, the base packages are refusing to install SQLite3. Therefore,
+# we install it here, just to be sure.
+RUN : \
+  && apt-get install sqlite3 \
+

--- a/build/Dockerfile.python.tox
+++ b/build/Dockerfile.python.tox
@@ -1,4 +1,4 @@
-FROM better/dockerimages:build-python-latest
+FROM better/dockerimages:build-python-2
 LABEL maintainer="core-tech@better.com"
 
 ENV                               \
@@ -55,4 +55,4 @@ RUN :                    \
 # we install it here, just to be sure.
 RUN : \
   && apt-get install sqlite3 \
-
+  

--- a/hooks/build
+++ b/hooks/build
@@ -22,7 +22,7 @@ BUILD_DEPENDENCIES_MAP=(
   make               %
   gnupg              %
   docker             docker.io
-  sqlite             %
+  sqlite             sqlite3
   openssh            openssh-client
   yaml-dev           libyaml-dev
   zlib-dev           zlib1g-dev


### PR DESCRIPTION
- Manually ensure that SQLite3 is installed for the tox image
- Specify SQLite3 as the SQLite to install
