### PR TITLE
DP-233  Openblas before numpy

### DIFF
--- a/base/Dockerfile.dataengineering
+++ b/base/Dockerfile.dataengineering
@@ -31,7 +31,7 @@ COPY                                         \
 RUN :                                                         \
   && apt-get update                                           \
   # Run common install scripts                                \
-  && apt-get install wget git less bash curl openssl coreutils ca-certificates jq tar \
+  && apt-get install libopenblas-dev wget git less bash curl openssl coreutils ca-certificates jq tar -y \
   && chmod +x /tmp/scripts/common/install-rds-certificates.sh \
   && chmod +x /tmp/scripts/common/install-sops.sh             \
   && /tmp/scripts/common/install-rds-certificates.sh          \


### PR DESCRIPTION
Adding openblas before numpy build so that we use the fast linear algebra routines.

Referenced in this conversation.
https://github.com/better/mortgage/pull/56018/files#diff-eaac7d2d4b24d176177abb65f238bccb119b5b06023f153ea50e75df9c01801e
